### PR TITLE
Switch to use QueryStream method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/G-Research/geras
 
 require (
-	github.com/G-Research/opentsdb-goclient querystream
+	github.com/G-Research/opentsdb-goclient v0.0.0-20190913102601-c8d547baa56d
 	github.com/OneOfOne/xxhash v1.2.5 // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/G-Research/geras
 
 require (
-	github.com/G-Research/opentsdb-goclient v0.0.0-20190913102601-c8d547baa56d
+	github.com/G-Research/opentsdb-goclient querystream
 	github.com/OneOfOne/xxhash v1.2.5 // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/G-Research/geras
 
 require (
-	github.com/G-Research/opentsdb-goclient v0.0.0-20190913102601-c8d547baa56d
+	github.com/G-Research/opentsdb-goclient v0.0.0-20191026082808-38a8952042a6
 	github.com/OneOfOne/xxhash v1.2.5 // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/G-Research/opentsdb-goclient v0.0.0-20190913102601-c8d547baa56d h1:+8xpXlmHoxC9+QvQF+0+lNYtZMrVHkpO+ohW010rJ90=
 github.com/G-Research/opentsdb-goclient v0.0.0-20190913102601-c8d547baa56d/go.mod h1:oVqXUYMDThF8Uz8WH3f80BlB7+Y5BV4wDtqQ06e4m7g=
+github.com/G-Research/opentsdb-goclient v0.0.0-20191026082808-38a8952042a6 h1:7xuo1D1QuLoV+VUGH9F0YKWR3iB8hjxiJ+Pemk6n+BU=
+github.com/G-Research/opentsdb-goclient v0.0.0-20191026082808-38a8952042a6/go.mod h1:oVqXUYMDThF8Uz8WH3f80BlB7+Y5BV4wDtqQ06e4m7g=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -585,7 +585,7 @@ func TestConvertOpenTSDBResultsToSeriesResponse(t *testing.T) {
 		},
 	}
 	for _, test := range testCases {
-		converted, err := convertOpenTSDBResultsToSeriesResponse(test.input)
+		converted, err := convertOpenTSDBResultsToSeriesResponse(&test.input)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err.Error())
 		}

--- a/test/faketsdb.go
+++ b/test/faketsdb.go
@@ -121,6 +121,11 @@ func query(r *http.Request, body []byte) interface{} {
 		}
 
 		r := getResults(int(param.Start.(float64)), int(param.End.(float64)), q)
+		if r == nil {
+			err := makeError(fmt.Sprintf("No such name for 'metrics': '%s'", q.Metric))
+			err["error"].(map[string]interface{})["code"] = 400
+			return err
+		}
 		results = append(results, r...)
 	}
 	return results
@@ -217,7 +222,7 @@ func queryLast(r *http.Request, body []byte) interface{} {
 func makeError(msg string) map[string]interface{} {
 	log.Printf("error: %s", msg)
 	return map[string]interface{}{
-		"error": map[string]string{
+		"error": map[string]interface{}{
 			"message": msg,
 		},
 	}

--- a/test/faketsdb.go
+++ b/test/faketsdb.go
@@ -218,7 +218,7 @@ func makeError(msg string) map[string]interface{} {
 	log.Printf("error: %s", msg)
 	return map[string]interface{}{
 		"error": map[string]string{
-			"msg": msg,
+			"message": msg,
 		},
 	}
 }

--- a/test/faketsdb.go
+++ b/test/faketsdb.go
@@ -136,7 +136,7 @@ func getResults(start, end int, q client.SubQuery) []client.QueryRespItem {
 	var n int
 	_, err := fmt.Sscanf(q.Metric, "test.%c.%d", &a, &n)
 	if err != nil || n >= *flagNumberMetrics {
-		log.Printf("Dropped query for %q, %v", err)
+		log.Printf("Dropped query for %q, %v", q.Metric, err)
 		return nil
 	}
 

--- a/vendor/github.com/G-Research/opentsdb-goclient/client/put.go
+++ b/vendor/github.com/G-Research/opentsdb-goclient/client/put.go
@@ -58,6 +58,13 @@ func (data *DataPoint) String() string {
 	return string(content)
 }
 
+// DataPointByTimestamp implements sort.Interface for sorting by timestamp.
+type DataPointByTimestamp []*DataPoint
+
+func (dp DataPointByTimestamp) Len() int           { return len(dp) }
+func (dp DataPointByTimestamp) Swap(i, j int)      { dp[i], dp[j] = dp[j], dp[i] }
+func (dp DataPointByTimestamp) Less(i, j int) bool { return dp[i].Timestamp < dp[j].Timestamp }
+
 // PutError holds the error message for each putting DataPoint instance.
 // Only calling PUT() with "details" query parameter, the reponse of
 // the failed put data operation can contain an array PutError instance

--- a/vendor/github.com/G-Research/opentsdb-goclient/client/query_last.go
+++ b/vendor/github.com/G-Research/opentsdb-goclient/client/query_last.go
@@ -134,10 +134,11 @@ func (c *clientImpl) QueryLast(param QueryLastParam) (*QueryLastResponse, error)
 		return nil, errors.New("The given query param is invalid.\n")
 	}
 	queryEndpoint := fmt.Sprintf("%s%s", c.tsdbEndpoint, QueryLastPath)
-	reqBodyCnt, err := getQueryBodyContents(&param)
+	resultByte, err := json.Marshal(param)
 	if err != nil {
-		return nil, err
+		return nil, errors.New(fmt.Sprintf("Failed to marshal query param: %v\n", err))
 	}
+	reqBodyCnt := string(resultByte)
 	queryResp := QueryLastResponse{}
 	if err = c.sendRequest(PostMethod, queryEndpoint, reqBodyCnt, &queryResp); err != nil {
 		return nil, err

--- a/vendor/github.com/G-Research/opentsdb-goclient/client/suggest.go
+++ b/vendor/github.com/G-Research/opentsdb-goclient/client/suggest.go
@@ -88,7 +88,6 @@ func (c *clientImpl) Suggest(sugParam SuggestParam) (*SuggestResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println(reqBodyCnt)
 	sugResp := SuggestResponse{}
 	if err := c.sendRequest(PostMethod, sugEndpoint, reqBodyCnt, &sugResp); err != nil {
 		return nil, err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/G-Research/opentsdb-goclient v0.0.0-20190913102601-c8d547baa56d
+# github.com/G-Research/opentsdb-goclient v0.0.0-20191026082808-38a8952042a6
 github.com/G-Research/opentsdb-goclient/client
 github.com/G-Research/opentsdb-goclient/config
 # github.com/beorn7/perks v1.0.1
@@ -82,8 +82,8 @@ google.golang.org/genproto/googleapis/api/httpbody
 google.golang.org/genproto/protobuf/field_mask
 # google.golang.org/grpc v1.22.1
 google.golang.org/grpc
-google.golang.org/grpc/codes
 google.golang.org/grpc/health/grpc_health_v1
+google.golang.org/grpc/codes
 google.golang.org/grpc/status
 google.golang.org/grpc/balancer
 google.golang.org/grpc/balancer/roundrobin


### PR DESCRIPTION
Depends on https://github.com/G-Research/opentsdb-goclient/pull/8.

This streams timeseries back rather than loading them all into memory. Provides a predictable memory usage when a large number of timeseries are requested.