### PR TITLE
Avoid an extra slice for datapoints, just encode straight into chunks

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -458,7 +458,8 @@ func convertOpenTSDBResultsToSeriesResponse(respI *opentsdb.QueryRespItem) (*sto
 			return nil, 0, err
 		}
 		var minTime int64
-		// Maximum 120 datapoints in a chunk
+		// Maximum 120 datapoints in a chunk -- this is a Thanos recommendation, see
+		// https://app.slack.com/client/T08PSQ7BQ/CL25937SP/thread/CL25937SP-1572162942.034700
 		for ; i < len(dps) && (minTime == 0 || i % 120 != 0); i++ {
 			dp := dps[i]
 			if minTime == 0 {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -460,6 +460,7 @@ func convertOpenTSDBResultsToSeriesResponse(respI *opentsdb.QueryRespItem) (*sto
 		var minTime int64
 		// Maximum 120 datapoints in a chunk -- this is a Thanos recommendation, see
 		// https://app.slack.com/client/T08PSQ7BQ/CL25937SP/thread/CL25937SP-1572162942.034700
+		// (on https://slack.cncf.io).
 		for ; i < len(dps) && (minTime == 0 || i % 120 != 0); i++ {
 			dp := dps[i]
 			if minTime == 0 {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -458,8 +458,8 @@ func convertOpenTSDBResultsToSeriesResponse(respI *opentsdb.QueryRespItem) (*sto
 			return nil, 0, err
 		}
 		var minTime int64
-		// Maximum 65535 datapoints in a chunk
-		for ; i < len(dps) && (minTime == 0 || i % 65535 != 0); i++ {
+		// Maximum 120 datapoints in a chunk
+		for ; i < len(dps) && (minTime == 0 || i % 120 != 0); i++ {
 			dp := dps[i]
 			if minTime == 0 {
 				minTime = int64(dp.Timestamp)

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -667,7 +667,7 @@ func TestConvertOpenTSDBResultsToSeriesResponse(t *testing.T) {
 			},
 			expectedOutput: storepb.NewSeriesResponse(&storepb.Series{
 				Labels: []storepb.Label{{Name: "__name__", Value: "metric"}},
-				Chunks: []storepb.AggrChunk{{MinTime: 0, MaxTime: 0}},
+				Chunks: []storepb.AggrChunk{},
 			}),
 		},
 		{
@@ -705,7 +705,7 @@ func TestConvertOpenTSDBResultsToSeriesResponse(t *testing.T) {
 		},
 	}
 	for _, test := range testCases {
-		converted, err := convertOpenTSDBResultsToSeriesResponse(&test.input)
+		converted, _, err := convertOpenTSDBResultsToSeriesResponse(&test.input)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err.Error())
 		}


### PR DESCRIPTION
Also use max 120 samples in a chunk.

See discussion at https://app.slack.com/client/T08PSQ7BQ/CL25937SP/thread/CL25937SP-1572162942.034700 (cloud-native.slack.com).