### PR TITLE
Use literal prefix to speed up regex searches over metric names

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -359,7 +359,7 @@ func (store *OpenTSDBStore) getMatchingMetricNames(matcher storepb.LabelMatcher)
 					matchingMetrics = append(matchingMetrics, literalPrefix)
 				}
 			} else {
-				for i:=firstPossibleIndex; i<len(store.metricNames); i++ {
+				for i := firstPossibleIndex; i < len(store.metricNames); i++ {
 					v := store.metricNames[i]
 					if rx.MatchString(v) {
 						matchingMetrics = append(matchingMetrics, v)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -320,6 +321,7 @@ func (store *OpenTSDBStore) loadAllMetricNames(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	sort.Strings(metricNames)
 
 	store.metricsNamesLock.Lock()
 	store.metricNames = metricNames
@@ -349,9 +351,30 @@ func (store *OpenTSDBStore) getMatchingMetricNames(matcher storepb.LabelMatcher)
 		}
 		var matchingMetrics []string
 		store.metricsNamesLock.RLock()
-		for _, v := range store.metricNames {
-			if rx.MatchString(v) {
-				matchingMetrics = append(matchingMetrics, v)
+		literalPrefix, complete := rx.LiteralPrefix()
+		if literalPrefix != "" {
+			firstPossibleIndex := sort.SearchStrings(store.metricNames, literalPrefix)
+			if complete {
+				if firstPossibleIndex < len(store.metricNames) && store.metricNames[firstPossibleIndex] == literalPrefix {
+					matchingMetrics = append(matchingMetrics, literalPrefix)
+				}
+			} else {
+				for i:=firstPossibleIndex; i<len(store.metricNames); i++ {
+					v := store.metricNames[i]
+					if rx.MatchString(v) {
+						matchingMetrics = append(matchingMetrics, v)
+					} else {
+						if !strings.HasPrefix(v, literalPrefix) {
+							break
+						}
+					}
+				}
+			}
+		} else {
+			for _, v := range store.metricNames {
+				if rx.MatchString(v) {
+					matchingMetrics = append(matchingMetrics, v)
+				}
 			}
 		}
 		store.metricsNamesLock.RUnlock()

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -756,32 +756,32 @@ func TestGetMatchingMetricNames(t *testing.T) {
 	}{
 		{
 			input: storepb.LabelMatcher{
-				Name: "tagk",
-				Type: storepb.LabelMatcher_EQ,
+				Name:  "tagk",
+				Type:  storepb.LabelMatcher_EQ,
 				Value: "tagv",
 			},
 			expectedOutput: nil,
 		},
 		{
 			input: storepb.LabelMatcher{
-				Name: "__name__",
-				Type: storepb.LabelMatcher_NEQ,
+				Name:  "__name__",
+				Type:  storepb.LabelMatcher_NEQ,
 				Value: "value",
 			},
 			expectedOutput: nil,
 		},
 		{
 			input: storepb.LabelMatcher{
-				Name: "__name__",
-				Type: storepb.LabelMatcher_NRE,
+				Name:  "__name__",
+				Type:  storepb.LabelMatcher_NRE,
 				Value: "value",
 			},
 			expectedOutput: nil,
 		},
 		{
 			input: storepb.LabelMatcher{
-				Name: "__name__",
-				Type: storepb.LabelMatcher_EQ,
+				Name:  "__name__",
+				Type:  storepb.LabelMatcher_EQ,
 				Value: "metric.name",
 			},
 			expectedOutput: []string{
@@ -790,8 +790,8 @@ func TestGetMatchingMetricNames(t *testing.T) {
 		},
 		{
 			input: storepb.LabelMatcher{
-				Name: "__name__",
-				Type: storepb.LabelMatcher_RE,
+				Name:  "__name__",
+				Type:  storepb.LabelMatcher_RE,
 				Value: "tsd\\..*",
 			},
 			expectedOutput: []string{
@@ -804,8 +804,8 @@ func TestGetMatchingMetricNames(t *testing.T) {
 		},
 		{
 			input: storepb.LabelMatcher{
-				Name: "__name__",
-				Type: storepb.LabelMatcher_RE,
+				Name:  "__name__",
+				Type:  storepb.LabelMatcher_RE,
 				Value: "cpu\\.[a-z]?i.*",
 			},
 			expectedOutput: []string{

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -748,3 +748,113 @@ func TestConvertOpenTSDBResultsToSeriesResponse(t *testing.T) {
 		}
 	}
 }
+
+func TestGetMatchingMetricNames(t *testing.T) {
+	testCases := []struct {
+		input          storepb.LabelMatcher
+		expectedOutput []string
+	}{
+		{
+			input: storepb.LabelMatcher{
+				Name: "tagk",
+				Type: storepb.LabelMatcher_EQ,
+				Value: "tagv",
+			},
+			expectedOutput: nil,
+		},
+		{
+			input: storepb.LabelMatcher{
+				Name: "__name__",
+				Type: storepb.LabelMatcher_NEQ,
+				Value: "value",
+			},
+			expectedOutput: nil,
+		},
+		{
+			input: storepb.LabelMatcher{
+				Name: "__name__",
+				Type: storepb.LabelMatcher_NRE,
+				Value: "value",
+			},
+			expectedOutput: nil,
+		},
+		{
+			input: storepb.LabelMatcher{
+				Name: "__name__",
+				Type: storepb.LabelMatcher_EQ,
+				Value: "metric.name",
+			},
+			expectedOutput: []string{
+				"metric.name",
+			},
+		},
+		{
+			input: storepb.LabelMatcher{
+				Name: "__name__",
+				Type: storepb.LabelMatcher_RE,
+				Value: "tsd\\..*",
+			},
+			expectedOutput: []string{
+				"tsd.rpc.errors",
+				"tsd.rpc.exceptions",
+				"tsd.rpc.forbidden",
+				"tsd.rpc.received",
+				"tsd.rpc.unauthorized",
+			},
+		},
+		{
+			input: storepb.LabelMatcher{
+				Name: "__name__",
+				Type: storepb.LabelMatcher_RE,
+				Value: "cpu\\.[a-z]?i.*",
+			},
+			expectedOutput: []string{
+				"cpu.idle",
+				"cpu.irq",
+				"cpu.nice",
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		store := &OpenTSDBStore{}
+		store.metricNames = []string{
+			"cpu.idle",
+			"cpu.irq",
+			"cpu.nice",
+			"cpu.sys",
+			"cpu.usr",
+			"tsd.rpc.errors",
+			"tsd.rpc.exceptions",
+			"tsd.rpc.forbidden",
+			"tsd.rpc.received",
+			"tsd.rpc.unauthorized",
+		}
+		output, err := store.getMatchingMetricNames(test.input)
+
+		if test.expectedOutput != nil {
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err.Error())
+			}
+			if output == nil {
+				t.Error("Expected output but not got any")
+			} else if len(output) != len(test.expectedOutput) {
+				t.Error("Number of metrics does not match")
+			} else {
+				for i, expected := range test.expectedOutput {
+					if output[i] != expected {
+						t.Errorf("Metric %v doesn't match expected: %v", output[i], expected)
+					}
+				}
+			}
+		} else {
+			if output != nil {
+				t.Errorf("Unexpected output: %v", output)
+			}
+			if err == nil {
+				t.Error("Expected error but not got one")
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Implements logic outlined in #35 