### PR TITLE
Regexp wildcard simplication

### DIFF
--- a/pkg/regexputil/opt.go
+++ b/pkg/regexputil/opt.go
@@ -121,6 +121,12 @@ func expandRunes(s []rune) [][]rune {
 	return ret
 }
 
+// Wildcard attempts to convert the regexp into a wildcard form, that is, if it
+// can be represented as a glob pattern using only "*", it will return "string*"
+// and true. It is assumed the "*" glob character matches 0 or more characters
+// only (i.e. is exactly identical to ".*"). Literal strings (i.e. not
+// containing any "*" will also be returned, if you need to handle these
+// differently it is recommended to call List first).
 func (r Regexp) Wildcard() (string, bool) {
 	potential := r.wildcardRecurse([]*syntax.Regexp{r.pt}, 0, 0)
 	return string(potential), len(potential) > 0
@@ -153,7 +159,7 @@ func (r Regexp) wildcardRecurse(p []*syntax.Regexp, parentOp syntax.Op, level in
 			}
 			potential = append(potential, '*')
 		case syntax.OpLiteral:
-			if parentOp != syntax.OpConcat {
+			if parentOp != 0 && parentOp != syntax.OpConcat {
 				return nil
 			}
 			potential = append(potential, s.Rune...)

--- a/pkg/regexputil/opt.go
+++ b/pkg/regexputil/opt.go
@@ -125,8 +125,8 @@ func expandRunes(s []rune) [][]rune {
 // can be represented as a glob pattern using only "*", it will return "string*"
 // and true. It is assumed the "*" glob character matches 0 or more characters
 // only (i.e. is exactly identical to ".*"). Literal strings (i.e. not
-// containing any "*" will also be returned, if you need to handle these
-// differently it is recommended to call List first).
+// containing any "*") will also be returned, if you need to handle these
+// differently it is recommended to call List first.
 func (r Regexp) Wildcard() (string, bool) {
 	potential := r.wildcardRecurse([]*syntax.Regexp{r.pt}, 0, 0)
 	return string(potential), len(potential) > 0

--- a/pkg/regexputil/opt_test.go
+++ b/pkg/regexputil/opt_test.go
@@ -81,10 +81,12 @@ func TestWildcard(t *testing.T) {
 		{"", false, false, ""},
 		{".*", false, true, "*"},
 		{"test", false, true, "test"},
+		{"^test$", false, true, "test"},
 		{"test.*", false, true, "test*"},
 		{".*test.*", false, true, "*test*"},
 		{".*test", false, true, "*test"},
 		{".*test.*test", false, true, "*test*test"},
+		{"^test.*$", false, true, "test*"},
 
 		// Multiple stars, questionable but handled...
 		{".*.*test", false, true, "**test"},

--- a/pkg/regexputil/opt_test.go
+++ b/pkg/regexputil/opt_test.go
@@ -80,6 +80,7 @@ func TestWildcard(t *testing.T) {
 		// Normal cases we expect to handle
 		{"", false, false, ""},
 		{".*", false, true, "*"},
+		{"test", false, true, "test"},
 		{"test.*", false, true, "test*"},
 		{".*test.*", false, true, "*test*"},
 		{".*test", false, true, "*test"},

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -661,9 +661,9 @@ func convertPromQLMatcherToFilter(matcher storepb.LabelMatcher) (opentsdb.Filter
 		if items, ok := rx.List(); ok {
 			f.Type = "literal_or"
 			f.FilterExp = strings.Join(items, "|")
-		} else if matcher.Value == ".*" {
+		} else if wildcard, ok := rx.Wildcard(); ok {
 			f.Type = "wildcard"
-			f.FilterExp = "*"
+			f.FilterExp = wildcard
 		} else {
 			f.Type = "regexp"
 			f.FilterExp = "^(?:" + matcher.Value + ")$"

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -137,7 +137,7 @@ func TestComposeOpenTSDBQuery(t *testing.T) {
 					{
 						Type:  storepb.LabelMatcher_RE,
 						Name:  "host",
-						Value: "foo.*",
+						Value: "foo.+",
 					},
 					{
 						Type:  storepb.LabelMatcher_EQ,
@@ -160,7 +160,7 @@ func TestComposeOpenTSDBQuery(t *testing.T) {
 							{
 								Type:      "regexp",
 								Tagk:      "host",
-								FilterExp: "^(?:foo.*)$",
+								FilterExp: "^(?:foo.+)$",
 								GroupBy:   true,
 							},
 						},
@@ -284,6 +284,56 @@ func TestComposeOpenTSDBQuery(t *testing.T) {
 								Type:      "wildcard",
 								Tagk:      "host",
 								FilterExp: "*",
+								GroupBy:   true,
+							},
+							{
+								Type:      "not_literal_or",
+								Tagk:      "key",
+								FilterExp: "v",
+								GroupBy:   true,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			req: storepb.SeriesRequest{
+				MinTime: 0,
+				MaxTime: 100,
+				Matchers: []storepb.LabelMatcher{
+					{
+						Type:  storepb.LabelMatcher_RE,
+						Name:  "host",
+						Value: "foo.*",
+					},
+					{
+						Type:  storepb.LabelMatcher_EQ,
+						Name:  "__name__",
+						Value: "test.metric2",
+					},
+					{
+						Type:  storepb.LabelMatcher_NEQ,
+						Name:  "key",
+						Value: "v",
+					},
+				},
+				MaxResolutionWindow:     0,
+				Aggregates:              []storepb.Aggr{storepb.Aggr_MIN},
+				PartialResponseDisabled: false,
+			},
+			tsdbQ: &opentsdb.QueryParam{
+				Start: 0,
+				End:   100,
+				Queries: []opentsdb.SubQuery{
+					{
+						Aggregator: "none",
+						Metric:     "test.metric2",
+						Filters: []opentsdb.Filter{
+							{
+								Type:      "wildcard",
+								Tagk:      "host",
+								FilterExp: "foo*",
 								GroupBy:   true,
 							},
 							{


### PR DESCRIPTION
OpenTSDB can do more efficient queries if given a wildcard rather than a regexp. Simplify regexps that can be into a wildcard (i.e. `foo.*` -> `foo*`).