### PR TITLE
Add -metrics-name-rewriting option to replace '.' with ':'

### DIFF
--- a/cmd/geras/main.go
+++ b/cmd/geras/main.go
@@ -113,6 +113,7 @@ func main() {
 	allowedMetricNamesRE := flag.String("metrics-allowed-regexp", ".*", "Regexp of metrics to allow")
 	blockedMetricNamesRE := flag.String("metrics-blocked-regexp", "", "Regexp of metrics to block (empty disables blocking)")
 	enableMetricSuggestions := flag.Bool("metrics-suggestions", true, "Enable metric suggestions (can be expensive)")
+	enableMetricNameRewriting := flag.Bool("metrics-name-rewriting", false, "Rewrite '.' to ':' in all responses (Prometheus remote_read won't accept '.', while Thanos will)")
 	var labels multipleStringFlags
 	flag.Var(&labels, "label", "Label to expose on the Store API, of the form '<key>=<value>'. May be repeated.")
 	flag.Parse()
@@ -183,7 +184,7 @@ func main() {
 	prometheus.DefaultRegisterer.MustRegister(version.NewCollector("geras"))
 
 	// create openTSDBStore and expose its api on a grpc server
-	srv, err := store.NewOpenTSDBStore(logger, client, prometheus.DefaultRegisterer, *refreshInterval, storeLabels, allowedMetricNames, blockedMetricNames, *enableMetricSuggestions, *healthcheckMetric)
+	srv, err := store.NewOpenTSDBStore(logger, client, prometheus.DefaultRegisterer, *refreshInterval, storeLabels, allowedMetricNames, blockedMetricNames, *enableMetricSuggestions, *enableMetricNameRewriting, *healthcheckMetric)
 	if err != nil {
 		level.Error(logger).Log("err", err)
 		os.Exit(1)

--- a/cmd/geras/main.go
+++ b/cmd/geras/main.go
@@ -113,7 +113,7 @@ func main() {
 	allowedMetricNamesRE := flag.String("metrics-allowed-regexp", ".*", "Regexp of metrics to allow")
 	blockedMetricNamesRE := flag.String("metrics-blocked-regexp", "", "Regexp of metrics to block (empty disables blocking)")
 	enableMetricSuggestions := flag.Bool("metrics-suggestions", true, "Enable metric suggestions (can be expensive)")
-	enableMetricNameRewriting := flag.Bool("metrics-name-rewriting", false, "Rewrite '.' to ':' in all responses (Prometheus remote_read won't accept '.', while Thanos will)")
+	enableMetricNameRewriting := flag.Bool("metrics-name-response-rewriting", false, "Rewrite '.' to ':' in all responses (Prometheus remote_read won't accept '.', while Thanos will)")
 	var labels multipleStringFlags
 	flag.Var(&labels, "label", "Label to expose on the Store API, of the form '<key>=<value>'. May be repeated.")
 	flag.Parse()

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -36,19 +36,21 @@ type OpenTSDBStore struct {
 	metricRefreshInterval                  time.Duration
 	allowedMetricNames, blockedMetricNames *regexp.Regexp
 	enableMetricSuggestions                bool
+	enableMetricNameRewriting bool
 	storeLabels                            []storepb.Label
 	healthcheckMetric                      string
 	aggregateToDownsample                  map[storepb.Aggr]string
 	downsampleToAggregate                  map[string]storepb.Aggr
 }
 
-func NewOpenTSDBStore(logger log.Logger, client opentsdb.ClientContext, reg prometheus.Registerer, interval time.Duration, storeLabels []storepb.Label, allowedMetricNames, blockedMetricNames *regexp.Regexp, enableMetricSuggestions bool, healthcheckMetric string) (*OpenTSDBStore, error) {
+func NewOpenTSDBStore(logger log.Logger, client opentsdb.ClientContext, reg prometheus.Registerer, interval time.Duration, storeLabels []storepb.Label, allowedMetricNames, blockedMetricNames *regexp.Regexp, enableMetricSuggestions, enableMetricNameRewriting bool, healthcheckMetric string) (*OpenTSDBStore, error) {
 	store := &OpenTSDBStore{
 		logger:                  log.With(logger, "component", "opentsdb"),
 		openTSDBClient:          client,
 		internalMetrics:         newInternalMetrics(reg),
 		metricRefreshInterval:   interval,
 		enableMetricSuggestions: enableMetricSuggestions,
+		enableMetricNameRewriting: enableMetricNameRewriting,
 		storeLabels:             storeLabels,
 		allowedMetricNames:      allowedMetricNames,
 		blockedMetricNames:      blockedMetricNames,
@@ -233,7 +235,7 @@ func (store *OpenTSDBStore) Series(
 			if respI.Error != nil {
 				return respI.Error
 			}
-			res, count, err := convertOpenTSDBResultsToSeriesResponse(respI, store.downsampleToAggregate)
+			res, count, err := convertOpenTSDBResultsToSeriesResponse(respI, store.downsampleToAggregate, store.enableMetricNameRewriting)
 			if err != nil {
 				return err
 			}
@@ -553,14 +555,19 @@ func (store *OpenTSDBStore) checkMetricNames(metricNames []string, fullBlock boo
 	return allowed, warnings, nil
 }
 
-func convertOpenTSDBResultsToSeriesResponse(respI *opentsdb.QueryRespItem, downsampleToAggregate map[string]storepb.Aggr) (*storepb.SeriesResponse, int, error) {
+func convertOpenTSDBResultsToSeriesResponse(respI *opentsdb.QueryRespItem, downsampleToAggregate map[string]storepb.Aggr, rewriteName bool) (*storepb.SeriesResponse, int, error) {
 	seriesLabels := make([]storepb.Label, len(respI.Tags))
 	i := 0
 	for k, v := range respI.Tags {
 		seriesLabels[i] = storepb.Label{Name: k, Value: v}
 		i++
 	}
-	seriesLabels = append(seriesLabels, storepb.Label{Name: "__name__", Value: respI.Metric})
+
+	name := respI.Metric
+	if rewriteName {
+		name = strings.ReplaceAll(name, ".", ":")
+	}
+	seriesLabels = append(seriesLabels, storepb.Label{Name: "__name__", Value: name})
 
 	downsampleFunction := "none"
 	if hyphenIndex := strings.Index(respI.Query.Downsample, "-"); hyphenIndex >= 0 {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -36,7 +36,7 @@ type OpenTSDBStore struct {
 	metricRefreshInterval                  time.Duration
 	allowedMetricNames, blockedMetricNames *regexp.Regexp
 	enableMetricSuggestions                bool
-	enableMetricNameRewriting bool
+	enableMetricNameRewriting              bool
 	storeLabels                            []storepb.Label
 	healthcheckMetric                      string
 	aggregateToDownsample                  map[storepb.Aggr]string
@@ -45,16 +45,16 @@ type OpenTSDBStore struct {
 
 func NewOpenTSDBStore(logger log.Logger, client opentsdb.ClientContext, reg prometheus.Registerer, interval time.Duration, storeLabels []storepb.Label, allowedMetricNames, blockedMetricNames *regexp.Regexp, enableMetricSuggestions, enableMetricNameRewriting bool, healthcheckMetric string) (*OpenTSDBStore, error) {
 	store := &OpenTSDBStore{
-		logger:                  log.With(logger, "component", "opentsdb"),
-		openTSDBClient:          client,
-		internalMetrics:         newInternalMetrics(reg),
-		metricRefreshInterval:   interval,
-		enableMetricSuggestions: enableMetricSuggestions,
+		logger:                    log.With(logger, "component", "opentsdb"),
+		openTSDBClient:            client,
+		internalMetrics:           newInternalMetrics(reg),
+		metricRefreshInterval:     interval,
+		enableMetricSuggestions:   enableMetricSuggestions,
 		enableMetricNameRewriting: enableMetricNameRewriting,
-		storeLabels:             storeLabels,
-		allowedMetricNames:      allowedMetricNames,
-		blockedMetricNames:      blockedMetricNames,
-		healthcheckMetric:       healthcheckMetric,
+		storeLabels:               storeLabels,
+		allowedMetricNames:        allowedMetricNames,
+		blockedMetricNames:        blockedMetricNames,
+		healthcheckMetric:         healthcheckMetric,
 	}
 	err := store.populateMaps()
 	if err != nil {


### PR DESCRIPTION
Without this we do this for requests but not responses, which we got
away with because Thanos doesn't validate the metric names as closely.
But Prometheus remote_read doesn't allow '.', so always replace the
__name__ with the ':' version.

An option for now because this is confusing behaviour:
- Matches on `__name__` will use the '.' version, but return the
  ':' version. i.e. `{__name__="tsd.rpc.recieved"}` will return
  "tsd:rpc:recieved"

Fixes #79.
