### PR TITLE
Ensure labels are sorted and replica labels are included

### DIFF
--- a/cmd/geras/main.go
+++ b/cmd/geras/main.go
@@ -185,11 +185,7 @@ func main() {
 	prometheus.DefaultRegisterer.MustRegister(version.NewCollector("geras"))
 
 	// create openTSDBStore and expose its api on a grpc server
-	srv, err := store.NewOpenTSDBStore(logger, client, prometheus.DefaultRegisterer, *refreshInterval, *refreshTimeout, storeLabels, allowedMetricNames, blockedMetricNames, *enableMetricSuggestions, *enableMetricNameRewriting, *healthcheckMetric)
-	if err != nil {
-		level.Error(logger).Log("err", err)
-		os.Exit(1)
-	}
+	srv := store.NewOpenTSDBStore(logger, client, prometheus.DefaultRegisterer, *refreshInterval, *refreshTimeout, storeLabels, allowedMetricNames, blockedMetricNames, *enableMetricSuggestions, *enableMetricNameRewriting, *healthcheckMetric)
 	grpcSrv := grpc.NewServer(
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -44,14 +44,14 @@ type OpenTSDBStore struct {
 }
 
 var (
-	aggregateToDownsample                  = map[storepb.Aggr]string{
+	aggregateToDownsample = map[storepb.Aggr]string{
 		storepb.Aggr_COUNT:   "count",
 		storepb.Aggr_SUM:     "sum",
 		storepb.Aggr_MIN:     "min",
 		storepb.Aggr_MAX:     "max",
 		storepb.Aggr_COUNTER: "avg",
 	}
-	downsampleToAggregate                  map[string]storepb.Aggr
+	downsampleToAggregate map[string]storepb.Aggr
 )
 
 func init() {
@@ -157,10 +157,10 @@ func (store *OpenTSDBStore) Info(
 	ctx context.Context,
 	req *storepb.InfoRequest) (*storepb.InfoResponse, error) {
 	res := storepb.InfoResponse{
-		MinTime: 0,
-		MaxTime: math.MaxInt64,
-		Labels:  store.storeLabels,
-		LabelSets: []storepb.LabelSet{{Labels:store.storeLabels}},
+		MinTime:   0,
+		MaxTime:   math.MaxInt64,
+		Labels:    store.storeLabels,
+		LabelSets: []storepb.LabelSet{{Labels: store.storeLabels}},
 	}
 	err := store.timedTSDBOp("query", func() error {
 		now := time.Now().Unix()
@@ -589,7 +589,7 @@ func (store *OpenTSDBStore) convertOpenTSDBResultsToSeriesResponse(respI *opents
 		if k == "__name__" {
 			seriesLabels[i] = storepb.Label{Name: k, Value: name}
 		} else if v, ok := store.storeLabelsMap[k]; ok {
-		  seriesLabels[i] = storepb.Label{Name: k, Value: v}
+			seriesLabels[i] = storepb.Label{Name: k, Value: v}
 		} else {
 			seriesLabels[i] = storepb.Label{Name: k, Value: respI.Tags[k]}
 		}

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -1152,7 +1152,7 @@ func TestConvertOpenTSDBResultsToSeriesResponse(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected error: %s", err.Error())
 		}
-		converted, _, err := convertOpenTSDBResultsToSeriesResponse(&test.input, store.downsampleToAggregate)
+		converted, _, err := store.convertOpenTSDBResultsToSeriesResponse(&test.input, store.downsampleToAggregate, false)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err.Error())
 		}

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -3,7 +3,6 @@ package store
 import (
 	"encoding/json"
 	"errors"
-	"os"
 	"regexp"
 	"testing"
 	"time"
@@ -13,6 +12,15 @@ import (
 
 	opentsdb "github.com/G-Research/opentsdb-goclient/client"
 )
+
+// Hides the log out; run with go test -v to see the output.
+type testLogger struct {
+	t *testing.T
+}
+func (tl testLogger) Write(n []byte) (int, error) {
+	tl.t.Log(string(n))
+	return len(n), nil
+}
 
 func TestComposeOpenTSDBQuery(t *testing.T) {
 	testCases := []struct {
@@ -878,7 +886,7 @@ func TestComposeOpenTSDBQuery(t *testing.T) {
 			allowedMetrics = test.allowedMetrics
 		}
 		store := NewOpenTSDBStore(
-			log.NewJSONLogger(os.Stdout), nil, nil, time.Duration(0), 1*time.Minute, test.storeLabels, allowedMetrics, test.blockedMetrics, false, false, "foo")
+			log.NewJSONLogger(&testLogger{t}), nil, nil, time.Duration(0), 1*time.Minute, test.storeLabels, allowedMetrics, test.blockedMetrics, false, false, "foo")
 		store.metricNames = test.knownMetrics
 		p, _, err := store.composeOpenTSDBQuery(&test.req)
 		if test.err != nil {
@@ -1145,7 +1153,7 @@ func TestConvertOpenTSDBResultsToSeriesResponse(t *testing.T) {
 	}
 	for _, test := range testCases {
 		store := NewOpenTSDBStore(
-			log.NewJSONLogger(os.Stdout), nil, nil, time.Duration(0), 1*time.Minute, []storepb.Label{}, nil, nil, false, false, "foo")
+			log.NewJSONLogger(&testLogger{t}), nil, nil, time.Duration(0), 1*time.Minute, []storepb.Label{}, nil, nil, false, false, "foo")
 		converted, _, err := store.convertOpenTSDBResultsToSeriesResponse(&test.input)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err.Error())

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -17,6 +17,7 @@ import (
 type testLogger struct {
 	t *testing.T
 }
+
 func (tl testLogger) Write(n []byte) (int, error) {
 	tl.t.Log(string(n))
 	return len(n), nil
@@ -29,7 +30,6 @@ func TestComposeOpenTSDBQuery(t *testing.T) {
 		knownMetrics                   []string
 		err                            error
 		allowedMetrics, blockedMetrics *regexp.Regexp
-		storeLabels []storepb.Label
 	}{
 		{
 			knownMetrics: []string{"test.metric"},
@@ -886,7 +886,7 @@ func TestComposeOpenTSDBQuery(t *testing.T) {
 			allowedMetrics = test.allowedMetrics
 		}
 		store := NewOpenTSDBStore(
-			log.NewJSONLogger(&testLogger{t}), nil, nil, time.Duration(0), 1*time.Minute, test.storeLabels, allowedMetrics, test.blockedMetrics, false, false, "foo")
+			log.NewJSONLogger(&testLogger{t}), nil, nil, time.Duration(0), 1*time.Minute, nil, allowedMetrics, test.blockedMetrics, false, false, "foo")
 		store.metricNames = test.knownMetrics
 		p, _, err := store.composeOpenTSDBQuery(&test.req)
 		if test.err != nil {


### PR DESCRIPTION
Also send LabelSets in the response for newer Thanos versions (fixes #17).

This fixes 2 bugs, which combined made this a very confusing set of issues:
- Not including replica labels in the store labels (i.e. per timeseries). We actually weren't getting deduplication across OpenTSDB instances. Worse (and more confusingly) because this was just combining everything into the same series if there were multiple instances which had exactly the same timeseries labels and timestamp it may overlap and generate entirely invalid chunks.
- Labels were not sorted, which Thanos relies on for deduplication. Because opentsdb-goclient uses a go map to store the labels the labels actually had random ordering, so the previous issue sometimes manifested or not, depending if the sets got combined.