### PR TITLE
Add tests for period character

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,6 @@ Geras additionally listens on a HTTP port for Prometheus `/metrics` queries and 
         queries as a fast mitigation therefore an error is returned when a
         metric is blocked.
   -metrics-name-response-rewriting
-        Rewrite '.' to ':' and '-' to '_' in all responses (Prometheus
-        remote_read won't accept these, while Thanos will) (default true)
-  -metrics-name-response-rewriting
         Rewrite '.' to a defined character and other bad characters to '_' in all responses (Prometheus
         remote_read won't accept these, while Thanos will) (default true)
   -period-character-replace

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -379,9 +379,12 @@ func (store *OpenTSDBStore) getMatchingMetricNames(matcher storepb.LabelMatcher)
 	if matcher.Name != "__name__" {
 		return nil, errors.New("getMatchingMetricNames must be called on __name__ matcher")
 	}
-	if matcher.Type == storepb.LabelMatcher_EQ && store.periodCharacter != "" {
-		value := strings.Replace(matcher.Value, store.periodCharacter, ".", -1)
-		return []string{value}, nil
+	if matcher.Type == storepb.LabelMatcher_EQ {
+		if store.periodCharacter != "" {
+			value := strings.Replace(matcher.Value, store.periodCharacter, ".", -1)
+			return []string{value}, nil
+		}
+		return []string{matcher.Value}, nil
 	} else if matcher.Type == storepb.LabelMatcher_NEQ {
 		// we can support this, but we should not.
 		return nil, errors.New("NEQ (!=) is not supported for __name__")

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -1264,8 +1264,8 @@ func TestConvertOpenTSDBResultsToSeriesResponse(t *testing.T) {
 
 func TestGetMatchingMetricNames(t *testing.T) {
 	testCases := []struct {
-		input          storepb.LabelMatcher
-		expectedOutput []string
+		input           storepb.LabelMatcher
+		expectedOutput  []string
 		periodCharacter string
 	}{
 		{
@@ -1274,7 +1274,7 @@ func TestGetMatchingMetricNames(t *testing.T) {
 				Type:  storepb.LabelMatcher_EQ,
 				Value: "tagv",
 			},
-			expectedOutput: nil,
+			expectedOutput:  nil,
 			periodCharacter: ":",
 		},
 		{
@@ -1283,7 +1283,7 @@ func TestGetMatchingMetricNames(t *testing.T) {
 				Type:  storepb.LabelMatcher_NEQ,
 				Value: "value",
 			},
-			expectedOutput: nil,
+			expectedOutput:  nil,
 			periodCharacter: ":",
 		},
 		{
@@ -1292,7 +1292,7 @@ func TestGetMatchingMetricNames(t *testing.T) {
 				Type:  storepb.LabelMatcher_NRE,
 				Value: "value",
 			},
-			expectedOutput: nil,
+			expectedOutput:  nil,
 			periodCharacter: ":",
 		},
 		{

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -1266,6 +1266,7 @@ func TestGetMatchingMetricNames(t *testing.T) {
 	testCases := []struct {
 		input          storepb.LabelMatcher
 		expectedOutput []string
+		periodCharacter string
 	}{
 		{
 			input: storepb.LabelMatcher{
@@ -1274,6 +1275,7 @@ func TestGetMatchingMetricNames(t *testing.T) {
 				Value: "tagv",
 			},
 			expectedOutput: nil,
+			periodCharacter: ":",
 		},
 		{
 			input: storepb.LabelMatcher{
@@ -1282,6 +1284,7 @@ func TestGetMatchingMetricNames(t *testing.T) {
 				Value: "value",
 			},
 			expectedOutput: nil,
+			periodCharacter: ":",
 		},
 		{
 			input: storepb.LabelMatcher{
@@ -1290,6 +1293,7 @@ func TestGetMatchingMetricNames(t *testing.T) {
 				Value: "value",
 			},
 			expectedOutput: nil,
+			periodCharacter: ":",
 		},
 		{
 			input: storepb.LabelMatcher{
@@ -1300,6 +1304,7 @@ func TestGetMatchingMetricNames(t *testing.T) {
 			expectedOutput: []string{
 				"metric.name",
 			},
+			periodCharacter: ":",
 		},
 		{
 			input: storepb.LabelMatcher{
@@ -1314,6 +1319,7 @@ func TestGetMatchingMetricNames(t *testing.T) {
 				"tsd.rpc.received",
 				"tsd.rpc.unauthorized",
 			},
+			periodCharacter: ":",
 		},
 		{
 			input: storepb.LabelMatcher{
@@ -1326,6 +1332,41 @@ func TestGetMatchingMetricNames(t *testing.T) {
 				"cpu.irq",
 				"cpu.nice",
 			},
+			periodCharacter: ":",
+		},
+		{
+			input: storepb.LabelMatcher{
+				Name:  "__name__",
+				Type:  storepb.LabelMatcher_EQ,
+				Value: "cpu:idle",
+			},
+			expectedOutput: []string{
+				"cpu.idle",
+			},
+			periodCharacter: ":",
+		},
+		{
+			input: storepb.LabelMatcher{
+				Name:  "__name__",
+				Type:  storepb.LabelMatcher_EQ,
+				Value: "cpu__idle_time",
+			},
+			expectedOutput: []string{
+				"cpu.idle_time",
+			},
+			// '__' means '_' can still be passed through as an underscore
+			periodCharacter: "__",
+		},
+		{
+			input: storepb.LabelMatcher{
+				Name:  "__name__",
+				Type:  storepb.LabelMatcher_EQ,
+				Value: "cpu.idle",
+			},
+			expectedOutput: []string{
+				"cpu.idle",
+			},
+			periodCharacter: "",
 		},
 	}
 
@@ -1343,7 +1384,7 @@ func TestGetMatchingMetricNames(t *testing.T) {
 				"tsd.rpc.received",
 				"tsd.rpc.unauthorized",
 			},
-			periodCharacter: ":",
+			periodCharacter: test.periodCharacter,
 		}
 		output, err := store.getMatchingMetricNames(test.input)
 


### PR DESCRIPTION
This tests the option added in #87 by @johnseekins, and fixes a minor issue when it was set to empty (no name matchers worked, now setting it to empty means that the exact OpenTSDB name must be used).