### PR TITLE
Remove the goimport check

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
             
       - name: Check formatting
         run: |
-          files=$(gofmt -l ./...)
+          files=$(gofmt -l .)
           if [[ $files != "" ]]; then
             echo "Files need gofmt run on them:"
             echo "$files"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,16 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-
+            
+      - name: Check formatting
+        run: |
+          files=$(gofmt -l ./...)
+          if [[ $files != "" ]]; then
+            echo "Files need gofmt run on them:"
+            echo "$files"
+            exit 1
+          fi
+          
       - name: Build binary
         run: |
           go build ./cmd/...

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,15 +15,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Check formatting
-        run: |
-          files=$(go run golang.org/x/tools/cmd/goimports -l -local "github.com/G-Research" .)
-          if [[ $files != "" ]]; then
-            echo "Files need goimports running on them:"
-            echo "$files"
-            exit 1
-          fi
-
       - name: Build binary
         run: |
           go build ./cmd/...


### PR DESCRIPTION
For starters, the name is `Check formatting` and it does not check formatting. It checks imports.

But: The tool itself cannot cope with the `golang.org/x/tools` package: if you add the checksum it says via `go mod download` it then complains you need to `go mod tidy`, which then removes that checksum.

```
go: downloading golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a
go: updates to go.mod needed; to update it:
	go mod tidy
```
vs
```
missing go.sum entry for module providing package golang.org/x/tools/cmd/goimports; to add:
	go mod download golang.org/x/tools
```