### PR TITLE
remove deprecated circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,0 @@
-version: 2
-
-jobs: {}
-
-workflows:
-  version: 2


### PR DESCRIPTION
As GitHub actions are used, the goal of this PR is to remove unused CircleCI and disable that integration on the repo level

Resolves: https://github.com/G-Research/oss-portfolio-maturity/issues/74