### PR TITLE
enable dependabot for go and github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
The goal of this change is to enable DependaBot automated pull requests for upgrading go packages and keeping GitHub actions up-to-date

Resolves: https://github.com/G-Research/oss-portfolio-maturity/issues/86