### PR TITLE
Add user agent header to outgoing HTTP requests

### DIFF
--- a/cmd/geras/main.go
+++ b/cmd/geras/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/G-Research/geras/pkg/store"
 	"github.com/G-Research/geras/pkg/tracing"
+	"github.com/G-Research/geras/pkg/useragent"
 	"github.com/G-Research/opentsdb-goclient/config"
 
 	_ "net/http/pprof"
@@ -174,12 +175,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Set user agent header
+	var transport http.RoundTripper = opentsdb.DefaultTransport
+	transport = useragent.NewUserAgentTransport(transport, "geras/" + version.Version)
+
 	// initialize distributed tracing
 	flush := initTracer()
 	defer flush()
 
 	// initialize tracing
-	var transport http.RoundTripper = opentsdb.DefaultTransport
 	if *traceEnabled {
 		transport = TracedTransport{
 			originalTransport: transport,

--- a/pkg/useragent/useragent.go
+++ b/pkg/useragent/useragent.go
@@ -1,0 +1,27 @@
+package useragent
+
+import (
+	"net/http"
+)
+
+type UserAgentTransport struct {
+	base      http.RoundTripper
+	customUA  string
+}
+
+func NewUserAgentTransport(base http.RoundTripper, customUA string) *UserAgentTransport {
+	return &UserAgentTransport{
+		base:     base,
+		customUA: customUA,
+	}
+}
+
+func (t *UserAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	defaultUA := req.Header.Get("User-Agent")
+	if defaultUA != "" {
+		req.Header.Set("User-Agent", defaultUA+" "+t.customUA)
+	} else {
+		req.Header.Set("User-Agent", t.customUA)
+	}
+	return t.base.RoundTrip(req)
+}


### PR DESCRIPTION
Adds a `geras/<version>` string to the `User-Agent` header to the HTTP requests that are sent to OpenTSDB. 

This makes it possible to separate out geras traffic on the OpenTSDB side.