### PR TITLE
Fix integration tests

### DIFF
--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -1,32 +1,33 @@
-faketsdb:
-  build: faketsdb
-  ports:
-    - 4242:4242
+services:
+  faketsdb:
+    build: faketsdb
+    ports:
+      - "4242:4242"
 
-geras:
-  # Uncomment and comment out image below to build locally
-  #build: ..
-  # Default to "image" which is what GitHub actions builds
-  image: image
-  ports:
-    - 19000:19000
-    - 19001:19001
-  links:
-    - faketsdb
-  command:
-    - "-log.level=debug"
-    - "-opentsdb-address=faketsdb:4242"
-    - "-trace-dumpbody"
-    - "-grpc-listen=:19000"
-    - "-http-listen=:19001"
+  geras:
+    # Uncomment and comment out image below to build locally
+    #build: ..
+    # Default to "image" which is what GitHub actions builds
+    image: image
+    ports:
+      - "19000:19000"
+      - "19001:19001"
+    depends_on:
+      - faketsdb
+    command:
+      - "-log.level=debug"
+      - "-opentsdb-address=faketsdb:4242"
+      - "-trace-dumpbody"
+      - "-grpc-listen=:19000"
+      - "-http-listen=:19001"
 
-thanos:
-  image: quay.io/thanos/thanos:v0.18.0
-  container_name: thanos
-  ports:
-    - 10902:10902
-  links:
-    - geras
-  command:
-    - "query"
-    - "--store=geras:19000"
+  thanos:
+    image: quay.io/thanos/thanos:v0.18.0
+    container_name: thanos
+    ports:
+      - "10902:10902"
+    depends_on:
+      - geras
+    command:
+      - "query"
+      - "--store=geras:19000"

--- a/test/test-query.sh
+++ b/test/test-query.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 sudo apt-get install -y jq
 
-docker-compose up -d --force-recreate
+docker compose up -d --force-recreate
 if [[ $? != 0 ]]; then
-  docker-compose logs
+  docker compose logs
   exit 1
 fi
 

--- a/test/test-query.sh
+++ b/test/test-query.sh
@@ -10,8 +10,8 @@ fi
 set -e
 
 docker run --network container:thanos \
-  appropriate/curl --retry 10 --retry-delay 5 --retry-connrefused http://localhost:10902/-/healthy
+  alpine/curl --retry 10 --retry-delay 5 --retry-connrefused http://localhost:10902/-/healthy
 
 # We just check we get some JSON back for now...
 docker run --network container:thanos \
-  appropriate/curl --retry 2 --retry-delay 5 "http://localhost:10902/api/v1/query?query=test%3Aa%3A5&dedup=true&partial_response=true&time=1572629812.291&_=1572629811861" | jq .
+  alpine/curl --retry 2 --retry-delay 5 "http://localhost:10902/api/v1/query?query=test%3Aa%3A5&dedup=true&partial_response=true&time=1572629812.291&_=1572629811861" | jq .


### PR DESCRIPTION
Latest Ubuntu images have docker-compose V2 so this updates:
- docker-compose.yaml file format 
- calls to `docker-compose` -> `docker compose`

I've also update use of `appropriate/curl` to `alpine/curl` as the former hasn't been maintained for years.